### PR TITLE
Made getProvider Asynchronous

### DIFF
--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -141,7 +141,9 @@ export class MagicConnector extends Connector {
   }
 
   async getAccount(): Promise<string> {
-    const provider = new ethers.providers.Web3Provider(this.getProvider());
+    const provider = new ethers.providers.Web3Provider(
+      await this.getProvider()
+    );
     const signer = provider.getSigner();
     const account = await signer.getAddress();
     return account;
@@ -162,7 +164,7 @@ export class MagicConnector extends Connector {
     return output;
   }
 
-  getProvider() {
+  async getProvider() {
     if (this.provider) {
       return this.provider;
     }
@@ -172,7 +174,9 @@ export class MagicConnector extends Connector {
   }
 
   async getSigner(): Promise<Signer> {
-    const provider = new ethers.providers.Web3Provider(this.getProvider());
+    const provider = new ethers.providers.Web3Provider(
+      await this.getProvider()
+    );
     const signer = await provider.getSigner();
     return signer;
   }


### PR DESCRIPTION
Rainbow kit is expecting getProvider to be a promise hence giving error by calling ```.then()``` over it. this pr fixes the issue