### PR TITLE
[Bug fix] Disconnect on `MagicConnectConnector`

### DIFF
--- a/.changeset/tasty-seas-turn.md
+++ b/.changeset/tasty-seas-turn.md
@@ -2,4 +2,6 @@
 '@everipedia/wagmi-magic-connector': patch
 ---
 
-magic.user.disconnect() is no available for Magic Connect, relying on local storage instead
+- `magic.user.disconnect()` is no available for Magic Connect, relying on local storage instead
+- Require email input for `connect()` flow to continue once modal is open. Otherwise the Magic Connect
+modals appears even if the user quits the process manually.

--- a/.changeset/tasty-seas-turn.md
+++ b/.changeset/tasty-seas-turn.md
@@ -1,0 +1,5 @@
+---
+'@everipedia/wagmi-magic-connector': patch
+---
+
+magic.user.disconnect() is no available for Magic Connect, relying on local storage instead

--- a/src/lib/connectors/magicConnectConnector.ts
+++ b/src/lib/connectors/magicConnectConnector.ts
@@ -126,6 +126,17 @@ export class MagicConnectConnector extends MagicConnector {
   // So we use a local storage state to handle this information.
   // TODO Once connect API grows, integrate it
   async isAuthorized() {
+    if (localStorage.getItem(CONNECT_TIME_KEY) === null) {
+      return false;
+    }
     return parseInt(window.localStorage.getItem(CONNECT_TIME_KEY)) + CONNECT_DURATION > (new Date()).getTime()
   }
+
+  // Overrides disconnect because there is currently no proper way to disconnect a user from Magic
+  // Connect.
+  // So we use a local storage state to handle this information.
+  async disconnect(): Promise<void> {
+    window.localStorage.removeItem(CONNECT_TIME_KEY);
+  }
+
 }

--- a/src/lib/connectors/magicConnectConnector.ts
+++ b/src/lib/connectors/magicConnectConnector.ts
@@ -75,23 +75,23 @@ export class MagicConnectConnector extends MagicConnector {
           await magic.auth.loginWithEmailOTP({
             email: output.email,
           });
+
+          const signer = await this.getSigner();
+          const account = await signer.getAddress();
+
+          // As we have no way to know if a user is connected to Magic Connect we store a connect timestamp
+          // in local storage
+          window.localStorage.setItem(CONNECT_TIME_KEY, String((new Date()).getTime()));
+
+          return {
+            account,
+            chain: {
+              id: chainId,
+              unsupported: false,
+            },
+            provider,
+          };
         }
-
-        const signer = await this.getSigner();
-        const account = await signer.getAddress();
-
-        // As we have no way to know if a user is connected to Magic Connect we store a connect timestamp
-        // in local storage
-        window.localStorage.setItem(CONNECT_TIME_KEY, String((new Date()).getTime()));
-
-        return {
-          account,
-          chain: {
-            id: chainId,
-            unsupported: false,
-          },
-          provider,
-        };
       }
       throw new UserRejectedRequestError('User rejected request');
     } catch (error) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

In #33 the `disconnect()` method for `MagicConnectConnector` was not thoroughly tested and had a bug.

When calling `magic.user.disconnect()` for the Magic Connect SDK the following error is raised:
```
Magic RPC Error: [-32603] Internal error: Unsupported Magic Connect method.
```

This PR proposes a fix by instead relying on a local storage state.

