### PR TITLE
Fixes ESM Bundling

### DIFF
--- a/.changeset/healthy-sheep-turn.md
+++ b/.changeset/healthy-sheep-turn.md
@@ -1,0 +1,5 @@
+---
+'@everipedia/wagmi-magic-connector': patch
+---
+
+Adds post processing on build output for adding .js ext for ESM resolution

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "type": "module",
   "repository": "https://github.com/EveripediaNetwork/wagmi-magic-connector",
   "license": "MIT",
-  "keywords": ["wagmi", "extension", "magic"],
+  "keywords": [
+    "wagmi",
+    "extension",
+    "magic"
+  ],
   "scripts": {
     "build": "run-p build:*",
     "build:main": "tsc -p tsconfig.json",
@@ -16,7 +20,7 @@
     "fix:lint": "eslint src --ext .ts --fix",
     "watch:build": "tsc -p tsconfig.json -w",
     "reset-hard": "git clean -dfx && git reset --hard && yarn",
-    "release": "yarn build:module && changeset publish"
+    "release": "yarn build:module && tsc-esm-fix --target='build/module' --ext='.js' && changeset publish"
   },
   "engines": {
     "node": ">=10"
@@ -27,7 +31,8 @@
     "@magic-ext/oauth": "^7.1.0",
     "@magic-sdk/provider": "^13.1.0",
     "@wagmi/core": "^0.8.14",
-    "magic-sdk": "^13.1.0"
+    "magic-sdk": "^13.1.0",
+    "tsc-esm-fix": "^2.20.10"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.30.7",


### PR DESCRIPTION
# Changes
- Adds post process tsc-compiled outputs each time after build with https://github.com/antongolub/tsc-esm-fix which adds .js extension to build files which are not added by tsc compiler. 

# Screenshot
![CleanShot 2023-01-14 at 11 52 00@2x](https://user-images.githubusercontent.com/52039218/212458995-746b07ce-422e-4633-88e4-87960b519e66.png)
