### PR TITLE
Fixes node version error on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Setup Node.js 12.x
+      - name: Setup Node.js 14.x
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.14.x
 
       - name: Install Dependencies
         run: yarn


### PR DESCRIPTION
# Changes
- changes node version from 12.x to 14.14.x 

# Screenshot
<img width="1077" alt="CleanShot 2023-01-14 at 12 05 30@2x" src="https://user-images.githubusercontent.com/52039218/212459389-2822fb0c-3d3e-4498-9e35-47e62cce5d86.png">
