### PR TITLE
Adds API Key not provided error

### DIFF
--- a/.changeset/real-olives-fly.md
+++ b/.changeset/real-olives-fly.md
@@ -1,0 +1,5 @@
+---
+'@everipedia/wagmi-magic-connector': minor
+---
+
+Throws `api key not provided` error instead of `user rejected request` error

--- a/src/lib/connectors/magicAuthConnector.ts
+++ b/src/lib/connectors/magicAuthConnector.ts
@@ -54,6 +54,8 @@ export class MagicAuthConnector extends MagicConnector {
   }
 
   async connect() {
+    if (!this.magicOptions.apiKey)
+      throw new Error('Magic API Key is not provided.');
     try {
       const provider = await this.getProvider();
 

--- a/src/lib/connectors/magicConnectConnector.ts
+++ b/src/lib/connectors/magicConnectConnector.ts
@@ -32,6 +32,8 @@ export class MagicConnectConnector extends MagicConnector {
   }
 
   async connect() {
+    if (!this.magicOptions.apiKey)
+      throw new Error('Magic API Key is not provided.');
     try {
       const provider = await this.getProvider();
 


### PR DESCRIPTION
Closes https://github.com/EveripediaNetwork/wagmi-magic-connector/issues/50

# Changes
- Adds new error message when user forgets to enter API key