### PR TITLE
Login with email workaround

### DIFF
--- a/.changeset/metal-adults-search.md
+++ b/.changeset/metal-adults-search.md
@@ -1,7 +1,0 @@
----
-'@everipedia/wagmi-magic-connector': patch
----
-### Patch Changes
-
-- Fixing a bug that prevents login with email because of a MagicSDK naming convention recent change.
-- Dependencies update.

--- a/.changeset/metal-adults-search.md
+++ b/.changeset/metal-adults-search.md
@@ -1,0 +1,7 @@
+---
+'@everipedia/wagmi-magic-connector': patch
+---
+### Patch Changes
+
+- Fixing a bug that prevents login with email because of a MagicSDK naming convention recent change.
+- Dependencies update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @everipedia/wagmi-magic-connector
 
+## 0.10.1
+
+### Patch Changes
+
+- c7dfeaf: ### Patch Changes
+
+  - Fixing a bug that prevents login with email because of a MagicSDK naming convention recent change.
+  - Dependencies update.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @everipedia/wagmi-magic-connector
 
-## 0.10.1
-
-### Patch Changes
-
-- c7dfeaf: ### Patch Changes
-
-  - Fixing a bug that prevents login with email because of a MagicSDK naming convention recent change.
-  - Dependencies update.
-
 ## 0.10.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.24.0",
-    "@magic-ext/connect": "^6.1.0",
-    "@magic-ext/oauth": "^7.1.0",
-    "@magic-sdk/provider": "^13.1.0",
+    "@magic-ext/connect": "^6.7.0",
+    "@magic-ext/oauth": "^7.6.0",
+    "@magic-sdk/provider": "^13.6.0",
     "@wagmi/core": "^0.8.14",
-    "magic-sdk": "^13.1.0",
+    "magic-sdk": "^13.6.0",
     "tsc-esm-fix": "^2.20.10"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everipedia/wagmi-magic-connector",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "wagmi connector to connect with Magic SDK",
   "main": "build/module/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everipedia/wagmi-magic-connector",
-  "version": "0.10.1",
+  "version": "0.10.0",
   "description": "wagmi connector to connect with Magic SDK",
   "main": "build/module/index.js",
   "type": "module",

--- a/src/lib/connectors/magicConnectConnector.ts
+++ b/src/lib/connectors/magicConnectConnector.ts
@@ -73,9 +73,7 @@ export class MagicConnectConnector extends MagicConnector {
 
         // LOGIN WITH MAGIC LINK WITH EMAIL
         if (output.email) {
-          await magic.auth.loginWithEmailOTP({
-            email: output.email,
-          });
+          await magic.wallet.connectWithUI();
 
           const signer = await this.getSigner();
           let account = (await signer.getAddress()) as Address;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixing a bug that prevents login with email because of a MagicSDK naming convention recent change.

- **What is the current behavior?** (You can also link to an open issue here)

You can't login with email, `User rejected request` is trowed.

- **What is the new behavior (if this is a feature change)?**

The error has gone.

- **Other information**:

This is a workaround, some other functions may be affected by the root change in the MagicSDK, it should be updated with a new deployment asap.